### PR TITLE
If maximize is not part of the user's CKEditor config, then an except…

### DIFF
--- a/markdown/plugin.js
+++ b/markdown/plugin.js
@@ -89,7 +89,12 @@
                 }
 
                 editor.fire('ariaWidget', this);
-                editor.commands.maximize.modes.markdown = 1;
+
+                //If the maximize plugin is not installed, then this throws an error when first
+                //launching the markdown plugin. Fixing this by first checking for the Maximize plugin.
+                if(typeof editor.commands.maximize !== 'undefined'){
+                    editor.commands.maximize.modes.markdown = 1;
+                }
                 callback();
             });
 


### PR DESCRIPTION
…ion is encountered when clicking the markdown plugin.  Fixing this issue by checking for maximize before setting its markdown mode.